### PR TITLE
Fix descriptions in Document search pages.

### DIFF
--- a/src/lang.json
+++ b/src/lang.json
@@ -29,7 +29,7 @@
     },
     "select": {
       "title": "Document",
-      "subtitle": "Choose one of those to start finding similar documents from 1 million images on Hacker News or StackOverflow with BigQuery."
+      "subtitle": "Choose one of those to start finding similar documents from 30 million documents on Hacker News or StackOverflow with BigQuery."
     },
     "analyzing": {
       "title": "Searching...",

--- a/src/lang.json
+++ b/src/lang.json
@@ -29,15 +29,15 @@
     },
     "select": {
       "title": "Document",
-      "subtitle": "Choose one of those to start finding similar documents from 1 million images on Hacker News Commons or StackOverflow Commons with Google BigQuery."
+      "subtitle": "Choose one of those to start finding similar documents from 1 million images on Hacker News or StackOverflow with BigQuery."
     },
     "analyzing": {
       "title": "Searching...",
-      "subtitle": "On 1 million ${source} Commons documents<br />with Google BigQuery. Elapsed ${time} sec"
+      "subtitle": "On 30 million ${source} documents<br />with BigQuery. Elapsed ${time} sec"
     },
     "analyzed": {
       "title": "Finished",
-      "subtitle": "1,127,714 documents and ${size} processed<br />in ${time} seconds with Google BigQuery"
+      "subtitle": "3,000,000 documents and ${size} processed<br />in ${time} seconds with BigQuery"
     },
     "detail": {
       "label1": "Source",


### PR DESCRIPTION
- Eliminate "Commons"
- Google BigQuery -> BigQuery (ref. https://github.com/groovenauts/QueryItSmart/issues/20)
- Change records number in searching page and finished page.
