### PR TITLE
Add Stack Overflow posts in document selection and eliminate Hacker News stories

### DIFF
--- a/src/data/hacker_news.json
+++ b/src/data/hacker_news.json
@@ -1,22 +1,2 @@
 [
-    {
-      "id": 3751584,
-      "title": "RantRally",
-      "body": "RantRally - an audio based social media site launched this week. More info about the service below:&#60;p&#62;RantRally is a social site where users can share with others through the power of their voice. Call a toll free number, leave a message, and your 'Rant' attaches to your profile and is available for anyone to hear.&#60;p&#62;Your listeners know that it's you, and when they hear your voice they feel an emotional connection that could never exist with text alone. Call, connect, share. The web should be more than just text."
-    },
-    {
-      "id": 5585779,
-      "title": "Haunting photos from the 2013 Pulitzer Prize Winners",
-      "body": ""
-    },
-    {
-      "id": 1789945,
-      "title": "",
-      "body": "Unfortunately the underestimation of time behind technology is nothing new and not just an issue with mobile development. We get the same thing at work nearly every day. People come in, want a 50 page website designed from scratch, branded, built on a CMS, and programmed with lots of forms, Java functionality (simple jQuery stuff usually), and SEO and expect to pay $1000. When people like this come about, it's the professionals job to educate the client and help others understand how much really goes into development. Looking at a \"simple\" app or website that they'll spend minutes on (or more in some cases) makes it very easy to think, \"Well it took me 60 seconds to navigate this page OR I picked this game up in a few minutes and beat the first couple levels, therefore it must have been simple to build.\""
-    },
-    {
-      "id": 92082,
-      "title": "",
-      "body": "No Aristotle in the philosophy section?"
-    }
 ]

--- a/src/data/stackoverflow.json
+++ b/src/data/stackoverflow.json
@@ -1,5 +1,25 @@
 [
   {
+    "id": 92082,
+    "title": "Add a column with a default value to an existing table in SQL Server",
+    "body": "How can a column with a default value be added to an existing table in SQL Server 2000 / SQL Server 2005?"
+  },
+  {
+    "id": 5585779,
+    "title": "Converting String to Int in Java?",
+    "body": "<p>How can I convert a <code>String</code> to an <code>int</code> in Java?</p> <p>My String contains only numbers and I want to return the number it represents.</p> <p>For example, given the string <code>\"1234\"</code> the result should be the number <code>1234</code>.</p>"
+  },
+  {
+    "id": 503093,
+    "title": "How do I redirect to another page in jQuery?",
+    "body": "<p>How can I redirect the user from one page to another using jQuery?</p>"
+  },
+  {
+    "id": 1789945,
+    "title": "How to check if one string contains another substring in JavaScript?",
+    "body": "<p>Usually, I would expect a <code>String.contains()</code> method, but there doesn't seem to be one. What is a reasonable way to check for this?</p>"
+  },
+  {
     "id": 7535498,
     "title": "UIButton custom font vertical alignment",
     "body": "<p>I've got a <code>UIButton</code> which uses a custom font which is set when my view loads:</p> <pre><code>- (void)viewDidLoad { [super viewDidLoad]; self.searchButton.titleLabel.font = [UIFont fontWithName: @ FONTNAME size: 15.0 ]; } </code></pre> <p>The problem I've got is that the font is appearing to float up of the center line. If I comment out this line the default font appears vertically centered fine. But changing to the custom font breaks the vertical alignment.</p> <p>I'm getting the same issue on a Table Cell with a custom font too.</p> <p>Do I need to tell the view somewhere that the custom font is not as tall as other fonts?</p> <p>EDIT: I've just realized that the font I'm using is a Windows TrueType Font. I can use it fine in TextEdit on the Mac only a problem with the alignment in my App</p> <p><img src= http://i.stack.imgur.com/nRBCO.png alt= Button text not vertically centered ></p>"

--- a/src/lang.json
+++ b/src/lang.json
@@ -29,7 +29,7 @@
     },
     "select": {
       "title": "Document",
-      "subtitle": "Choose one of those to start finding similar documents from 30 million documents on Hacker News or StackOverflow with BigQuery."
+      "subtitle": "Choose one of those to start finding similar documents from 30 million documents on StackOverflow with BigQuery."
     },
     "analyzing": {
       "title": "Searching...",


### PR DESCRIPTION
I removed the Hacker News stories from document search select candidates, and added some Stack Overflow posts.
See comments in https://github.com/groovenauts/QueryItSmart/pull/24.