### PR TITLE
Remove tags and entity references in document search results

### DIFF
--- a/src/actions/searchDocumentActions.js
+++ b/src/actions/searchDocumentActions.js
@@ -8,7 +8,10 @@ const wrapSearchDocument = (id, sql) => dispatch => {
     dispatch({
       type: types.SEARCH_DOCUMENT_FINISHED,
       id,
-      results: res[0],
+      results: _.map(res[0], (doc, i) => {
+        doc.body = doc.body.replace(/<[^>]+>/g, "").replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/&amp;/g, "&").replace(/&[0-9a-zA-Z]+;/, "");
+        return doc;
+      }),
       totalBytesProcessed: _.get(res[2], 'totalBytesProcessed'),
       time: new Date()
     })

--- a/src/data/hacker_news.json
+++ b/src/data/hacker_news.json
@@ -1,22 +1,2 @@
 [
-    {
-      "id": 3751584,
-      "title": "RantRally",
-      "body": "RantRally - an audio based social media site launched this week. More info about the service below:&#60;p&#62;RantRally is a social site where users can share with others through the power of their voice. Call a toll free number, leave a message, and your 'Rant' attaches to your profile and is available for anyone to hear.&#60;p&#62;Your listeners know that it's you, and when they hear your voice they feel an emotional connection that could never exist with text alone. Call, connect, share. The web should be more than just text."
-    },
-    {
-      "id": 5585779,
-      "title": "Haunting photos from the 2013 Pulitzer Prize Winners",
-      "body": ""
-    },
-    {
-      "id": 1789945,
-      "title": "",
-      "body": "Unfortunately the underestimation of time behind technology is nothing new and not just an issue with mobile development. We get the same thing at work nearly every day. People come in, want a 50 page website designed from scratch, branded, built on a CMS, and programmed with lots of forms, Java functionality (simple jQuery stuff usually), and SEO and expect to pay $1000. When people like this come about, it's the professionals job to educate the client and help others understand how much really goes into development. Looking at a \"simple\" app or website that they'll spend minutes on (or more in some cases) makes it very easy to think, \"Well it took me 60 seconds to navigate this page OR I picked this game up in a few minutes and beat the first couple levels, therefore it must have been simple to build.\""
-    },
-    {
-      "id": 92082,
-      "title": "",
-      "body": "No Aristotle in the philosophy section?"
-    }
 ]

--- a/src/data/stackoverflow.json
+++ b/src/data/stackoverflow.json
@@ -1,5 +1,25 @@
 [
   {
+    "id": 92082,
+    "title": "Add a column with a default value to an existing table in SQL Server",
+    "body": "How can a column with a default value be added to an existing table in SQL Server 2000 / SQL Server 2005?"
+  },
+  {
+    "id": 5585779,
+    "title": "Converting String to Int in Java?",
+    "body": "<p>How can I convert a <code>String</code> to an <code>int</code> in Java?</p> <p>My String contains only numbers and I want to return the number it represents.</p> <p>For example, given the string <code>\"1234\"</code> the result should be the number <code>1234</code>.</p>"
+  },
+  {
+    "id": 503093,
+    "title": "How do I redirect to another page in jQuery?",
+    "body": "<p>How can I redirect the user from one page to another using jQuery?</p>"
+  },
+  {
+    "id": 1789945,
+    "title": "How to check if one string contains another substring in JavaScript?",
+    "body": "<p>Usually, I would expect a <code>String.contains()</code> method, but there doesn't seem to be one. What is a reasonable way to check for this?</p>"
+  },
+  {
     "id": 7535498,
     "title": "UIButton custom font vertical alignment",
     "body": "<p>I've got a <code>UIButton</code> which uses a custom font which is set when my view loads:</p> <pre><code>- (void)viewDidLoad { [super viewDidLoad]; self.searchButton.titleLabel.font = [UIFont fontWithName: @ FONTNAME size: 15.0 ]; } </code></pre> <p>The problem I've got is that the font is appearing to float up of the center line. If I comment out this line the default font appears vertically centered fine. But changing to the custom font breaks the vertical alignment.</p> <p>I'm getting the same issue on a Table Cell with a custom font too.</p> <p>Do I need to tell the view somewhere that the custom font is not as tall as other fonts?</p> <p>EDIT: I've just realized that the font I'm using is a Windows TrueType Font. I can use it fine in TextEdit on the Mac only a problem with the alignment in my App</p> <p><img src= http://i.stack.imgur.com/nRBCO.png alt= Button text not vertically centered ></p>"

--- a/src/data/stackoverflow.json
+++ b/src/data/stackoverflow.json
@@ -7,36 +7,36 @@
   {
     "id": 5585779,
     "title": "Converting String to Int in Java?",
-    "body": "<p>How can I convert a <code>String</code> to an <code>int</code> in Java?</p> <p>My String contains only numbers and I want to return the number it represents.</p> <p>For example, given the string <code>\"1234\"</code> the result should be the number <code>1234</code>.</p>"
+    "body": "How can I convert a String to an int in Java? My String contains only numbers and I want to return the number it represents. For example, given the string \"1234\" the result should be the number 1234."
   },
   {
     "id": 503093,
     "title": "How do I redirect to another page in jQuery?",
-    "body": "<p>How can I redirect the user from one page to another using jQuery?</p>"
+    "body": "How can I redirect the user from one page to another using jQuery?"
   },
   {
     "id": 1789945,
     "title": "How to check if one string contains another substring in JavaScript?",
-    "body": "<p>Usually, I would expect a <code>String.contains()</code> method, but there doesn't seem to be one. What is a reasonable way to check for this?</p>"
+    "body": "Usually, I would expect a String.contains() method, but there doesn't seem to be one. What is a reasonable way to check for this?"
   },
   {
     "id": 7535498,
     "title": "UIButton custom font vertical alignment",
-    "body": "<p>I've got a <code>UIButton</code> which uses a custom font which is set when my view loads:</p> <pre><code>- (void)viewDidLoad { [super viewDidLoad]; self.searchButton.titleLabel.font = [UIFont fontWithName: @ FONTNAME size: 15.0 ]; } </code></pre> <p>The problem I've got is that the font is appearing to float up of the center line. If I comment out this line the default font appears vertically centered fine. But changing to the custom font breaks the vertical alignment.</p> <p>I'm getting the same issue on a Table Cell with a custom font too.</p> <p>Do I need to tell the view somewhere that the custom font is not as tall as other fonts?</p> <p>EDIT: I've just realized that the font I'm using is a Windows TrueType Font. I can use it fine in TextEdit on the Mac only a problem with the alignment in my App</p> <p><img src= http://i.stack.imgur.com/nRBCO.png alt= Button text not vertically centered ></p>"
+    "body": "I've got a UIButton which uses a custom font which is set when my view loads: - (void)viewDidLoad { [super viewDidLoad]; self.searchButton.titleLabel.font = [UIFont fontWithName: @ FONTNAME size: 15.0 ]; }  The problem I've got is that the font is appearing to float up of the center line. If I comment out this line the default font appears vertically centered fine. But changing to the custom font breaks the vertical alignment. I'm getting the same issue on a Table Cell with a custom font too. Do I need to tell the view somewhere that the custom font is not as tall as other fonts? EDIT: I've just realized that the font I'm using is a Windows TrueType Font. I can use it fine in TextEdit on the Mac only a problem with the alignment in my App"
   },
   {
     "id": 10752055,
     "title": "Cross origin requests are only supported for HTTP. error when loading a local file",
-    "body": "<p>I'm trying to load a 3D model into Three.js with <code>JSONLoader</code> and that 3D model is in the same directory as the entire website.</p> <p>I'm getting the <code> Cross origin requests are only supported for HTTP. </code> error but I don't know what's causing it nor how to fix it.</p>"
+    "body": "I'm trying to load a 3D model into Three.js with JSONLoader and that 3D model is in the same directory as the entire website. I'm getting the  Cross origin requests are only supported for HTTP.  error but I don't know what's causing it nor how to fix it."
   },
   {
     "id": 730916,
     "title": "What's the difference between jQuery's replaceWith() and html()?",
-    "body": "<p>What's the difference between jQuery's replaceWith() and html() functions when HTML is being passed in as the parameter?</p>"
+    "body": "What's the difference between jQuery's replaceWith() and html() functions when HTML is being passed in as the parameter?"
   },
   {
     "id": 419472,
     "title": "Have a reloadData for a UITableView animate when changing",
-    "body": "<p>I have a UITableView that has two modes. When we switch between the modes I have a different number of sections and cells per section. Ideally it would do some cool animation when the table grows or shrinks.</p> <p>Here is the code I tried but it doesn't do anything:</p> <pre><code>CGContextRef context = UIGraphicsGetCurrentContext(); [UIView beginAnimations:nil context:context]; [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut]; [UIView setAnimationDuration:0.5]; [self.tableView reloadData]; [UIView commitAnimations]; </code></pre> <p>Any thoughts on how I could do this?</p>"
+    "body": "I have a UITableView that has two modes. When we switch between the modes I have a different number of sections and cells per section. Ideally it would do some cool animation when the table grows or shrinks. Here is the code I tried but it doesn't do anything: CGContextRef context = UIGraphicsGetCurrentContext(); [UIView beginAnimations:nil context:context]; [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut]; [UIView setAnimationDuration:0.5]; [self.tableView reloadData]; [UIView commitAnimations];  Any thoughts on how I could do this?"
   }
 ]

--- a/src/lang.json
+++ b/src/lang.json
@@ -29,7 +29,7 @@
     },
     "select": {
       "title": "Document",
-      "subtitle": "Choose one of those to start finding similar documents from 30 million documents on Hacker News or StackOverflow with BigQuery."
+      "subtitle": "Choose one of those to start finding similar documents from 30 million documents on StackOverflow with BigQuery."
     },
     "analyzing": {
       "title": "Searching...",


### PR DESCRIPTION
Fixes for https://github.com/groovenauts/QueryItSmart/issues/27.

I just remove HTML tags and Entity reference in document search candidate and results.

This pull request based upon the branch of https://github.com/groovenauts/QueryItSmart/pull/28 branch. Please merge #28 first.