### PR TITLE
Move content header to avoid collision with center icon in image search.

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -61,7 +61,7 @@ span {
   top: 50%;
   left: 50%;
   width: 70%;
-  transform: translate(-50%, calc(-50% - 320px));
+  transform: translate(-50%, calc(-50% - 400px));
   text-align: center;
   transition: all 1s;
   opacity: 1;


### PR DESCRIPTION
Fix for https://github.com/groovenauts/QueryItSmart/issues/22