### PR TITLE
Fix offset value to demand forecast query.

### DIFF
--- a/src/actions/forecastActions.js
+++ b/src/actions/forecastActions.js
@@ -25,9 +25,9 @@ const wrapRequest = (queryType, queryParams) => dispatch => {
 export const requestForecast = param => dispatch => {
   const { month, weekday, temperature, weather } = param
   const sql = QUERY.citibike.sql({
-    month,
-    wday: weekday,
-    temp: temperature,
+    month: parseInt(month)+1,
+    wday: parseInt(weekday)+1,
+    temp: parseInt(temperature)-10,
     weather
   })
   dispatch({

--- a/src/components/DemandForecast/Map.jsx
+++ b/src/components/DemandForecast/Map.jsx
@@ -25,7 +25,7 @@ class Map extends Component {
       this.heatmap = new google.maps.visualization.HeatmapLayer({
         dissipating: true,
         data: data,
-        maxIntensity: 1.0,
+        maxIntensity: 26.0,
         radius: 20,
         map: this.map
       })


### PR DESCRIPTION
The each parameter to demand forecast query has different offset.

- month: 1-origin (1-12)
- wday: 1-origin (1-7)
- temperature (-10-75 F)
- weather 0-origin (0-2)

Though all the parameters are passed to api with 0-origin values.
I fixed the offset of each parameter.

I also tuned `maxIntensity` in HeatmapLayer to show results in good resolution of usage predictions.